### PR TITLE
drivers: power: Fix Header Path for oplus_battery_*

### DIFF
--- a/drivers/power/oplus/charger_ic/oplus_battery_mtk6768R.h
+++ b/drivers/power/oplus/charger_ic/oplus_battery_mtk6768R.h
@@ -22,15 +22,15 @@
 #include <linux/uaccess.h>
 
 #include <mt-plat/charger_class.h>
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
 struct charger_manager;
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
 
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_init.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_init.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
 
 #define RT9471D 0
 #define RT9467 1

--- a/drivers/power/oplus/charger_ic/oplus_battery_mtk6769.h
+++ b/drivers/power/oplus/charger_ic/oplus_battery_mtk6769.h
@@ -22,15 +22,15 @@
 #include <linux/uaccess.h>
 
 #include <mt-plat/charger_class.h>
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
 struct charger_manager;
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
 
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_init.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_init.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
 
 #define RT9471D 0
 #define RT9467 1

--- a/drivers/power/oplus/charger_ic/oplus_battery_mtk6769R.h
+++ b/drivers/power/oplus/charger_ic/oplus_battery_mtk6769R.h
@@ -22,15 +22,15 @@
 #include <linux/uaccess.h>
 
 #include <mt-plat/charger_class.h>
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
 struct charger_manager;
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
 
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_init.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_init.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
 
 #define RT9471D 0
 #define RT9467 1

--- a/drivers/power/oplus/charger_ic/oplus_battery_mtk6781R.h
+++ b/drivers/power/oplus/charger_ic/oplus_battery_mtk6781R.h
@@ -22,15 +22,15 @@
 #include <linux/uaccess.h>
 
 #include <mt-plat/charger_class.h>
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
 struct charger_manager;
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
 
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_init.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_init.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
 
 typedef enum {
 	STEP_CHG_STATUS_STEP1 = 0,	/*16C~44C*/

--- a/drivers/power/oplus/charger_ic/oplus_battery_mtk6785.h
+++ b/drivers/power/oplus/charger_ic/oplus_battery_mtk6785.h
@@ -22,15 +22,15 @@
 #include <linux/uaccess.h>
 
 #include <mt-plat/charger_class.h>
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
 struct charger_manager;
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
 
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_init.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_init.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
 
 typedef enum {
 	STEP_CHG_STATUS_STEP1 = 0,	/*16C~44C*/

--- a/drivers/power/oplus/charger_ic/oplus_battery_mtk6785R.h
+++ b/drivers/power/oplus/charger_ic/oplus_battery_mtk6785R.h
@@ -22,15 +22,15 @@
 #include <linux/uaccess.h>
 
 #include <mt-plat/charger_class.h>
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
 struct charger_manager;
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
 
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_init.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_init.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
 
 typedef enum {
 	STEP_CHG_STATUS_STEP1 = 0,	/*16C~44C*/

--- a/drivers/power/oplus/charger_ic/oplus_battery_mtk6833R.h
+++ b/drivers/power/oplus/charger_ic/oplus_battery_mtk6833R.h
@@ -22,14 +22,14 @@
 #include <linux/uaccess.h>
 
 #include <mt-plat/charger_class.h>
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
 struct charger_manager;
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_init.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_init.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
 
 typedef enum {
 	STEP_CHG_STATUS_STEP1 = 0,	/*16C~44C*/

--- a/drivers/power/oplus/charger_ic/oplus_battery_mtk6853.h
+++ b/drivers/power/oplus/charger_ic/oplus_battery_mtk6853.h
@@ -21,14 +21,14 @@
 #include <linux/uaccess.h>
 
 #include <mt-plat/charger_class.h>
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
 struct charger_manager;
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_init.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_init.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
 
 typedef enum {
 	STEP_CHG_STATUS_STEP1 = 0,	/*16C~44C*/

--- a/drivers/power/oplus/charger_ic/oplus_battery_mtk6853R.h
+++ b/drivers/power/oplus/charger_ic/oplus_battery_mtk6853R.h
@@ -22,14 +22,14 @@
 #include <linux/uaccess.h>
 
 #include <mt-plat/charger_class.h>
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
 struct charger_manager;
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_init.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_init.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
 
 typedef enum {
 	STEP_CHG_STATUS_STEP1 = 0,	/*16C~44C*/

--- a/drivers/power/oplus/charger_ic/oplus_battery_mtk6873.h
+++ b/drivers/power/oplus/charger_ic/oplus_battery_mtk6873.h
@@ -21,14 +21,14 @@
 #include <linux/uaccess.h>
 
 
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/misc/mtk_gauge_time_service.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/include/mt-plat/charger_class.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
+#include "../drivers/power/supply/mediatek/misc/mtk_gauge_time_service.h"
+#include "../drivers/misc/mediatek/include/mt-plat/charger_class.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
 struct charger_manager;
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
 
 
 

--- a/drivers/power/oplus/charger_ic/oplus_battery_mtk6873R.h
+++ b/drivers/power/oplus/charger_ic/oplus_battery_mtk6873R.h
@@ -22,14 +22,14 @@
 #include <linux/uaccess.h>
 
 #include <mt-plat/charger_class.h>
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
 struct charger_manager;
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_init.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_init.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
 
 typedef enum {
 	STEP_CHG_STATUS_STEP1 = 0,	/*16C~44C*/

--- a/drivers/power/oplus/charger_ic/oplus_battery_mtk6877R.h
+++ b/drivers/power/oplus/charger_ic/oplus_battery_mtk6877R.h
@@ -22,15 +22,15 @@
 #include <linux/uaccess.h>
 
 #include <mt-plat/charger_class.h>
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
 struct charger_manager;
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
 
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_init.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_init.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
 
 typedef enum {
 	STEP_CHG_STATUS_STEP1 = 0,	/*16C~44C*/

--- a/drivers/power/oplus/charger_ic/oplus_battery_mtk6885.h
+++ b/drivers/power/oplus/charger_ic/oplus_battery_mtk6885.h
@@ -21,14 +21,14 @@
 #include <linux/uaccess.h>
 
 
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/misc/mtk_gauge_time_service.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/include/mt-plat/charger_class.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
+#include "../drivers/power/supply/mediatek/misc/mtk_gauge_time_service.h"
+#include "../drivers/misc/mediatek/include/mt-plat/charger_class.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
 struct charger_manager;
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
 
 //#include "../../../../kernel-4.9/drivers/power/supply/mediatek/misc/mtk_gauge_time_service.h"
 //#include "../../../../kernel-4.9/drivers/power/supply/mediatek/charger/charger_class.h"

--- a/drivers/power/oplus/charger_ic/oplus_battery_mtk6885R.h
+++ b/drivers/power/oplus/charger_ic/oplus_battery_mtk6885R.h
@@ -22,15 +22,15 @@
 #include <linux/uaccess.h>
 
 #include <mt-plat/charger_class.h>
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
 struct charger_manager;
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
 
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_init.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_init.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
 
 typedef enum {
 	STEP_CHG_STATUS_STEP1 = 0,	/*16C~44C*/

--- a/drivers/power/oplus/charger_ic/oplus_battery_mtk6889R.h
+++ b/drivers/power/oplus/charger_ic/oplus_battery_mtk6889R.h
@@ -22,15 +22,15 @@
 #include <linux/uaccess.h>
 
 #include <mt-plat/charger_class.h>
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
 struct charger_manager;
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
 
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_init.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_init.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
 
 typedef enum {
 	STEP_CHG_STATUS_STEP1 = 0,	/*16C~44C*/

--- a/drivers/power/oplus/charger_ic/oplus_battery_mtk6893R.h
+++ b/drivers/power/oplus/charger_ic/oplus_battery_mtk6893R.h
@@ -22,15 +22,15 @@
 #include <linux/uaccess.h>
 
 #include <mt-plat/charger_class.h>
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
-#include "../../../../kernel-4.14/drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/mtk_direct_charge_vdm.h"
 struct charger_manager;
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pe20_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_pdc_intf.h"
 
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_init.h"
-#include "../../../../kernel-4.14/drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_init.h"
+#include "../drivers/power/supply/mediatek/charger/mtk_charger_intf.h"
 
 typedef enum {
 	STEP_CHG_STATUS_STEP1 = 0,	/*16C~44C*/


### PR DESCRIPTION
The kernel path for mtk power drivers should be ../drivers/misc/mediatek/ , but for some reasons, the path here is ../../../../kernel-4.14/drivers/misc/mediatek/ , this is probably due to oplus's build system , it works fine in their enviroment, but for third party developer it throws error, so lets just define its correct path & fix the error.

Test: Error is fixed & kernel code compiles successfully.

Change-Id: Ie6930c4e0fc80c0453bebe1c9cf3d6cee87174ee
Co-authored-by: techyminati <sinha.aryan03@gmail.com>
Signed-off-by: Sarthak Roy <sarthakroy2002@gmail.com>